### PR TITLE
Fix auth2_basic keys in plugin_store_rows

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -66,7 +66,7 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
     result.email = user_details[:email]
     result.email_valid = result.email.present? && SiteSetting.oauth2_email_verified
 
-    current_info = ::PluginStore.get("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}")
+    current_info = ::PluginStore.get("oauth2_basic", "oauth2_basic_#{user_details[:user_id]}")
     if current_info
       result.user = User.where(id: current_info[:user_id]).first
     end
@@ -75,7 +75,7 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
   end
 
   def after_create_account(user, auth)
-    ::PluginStore.set("oauth2_basic", "oauth2_basic_user_#{auth[:extra_data][:oauth2_basic_user_id]}", {user_id: user.id })
+    ::PluginStore.set("oauth2_basic", "oauth2_basic_#{auth[:extra_data][:oauth2_basic_user_id]}", {user_id: user.id })
   end
 end
 


### PR DESCRIPTION
Right now, the plugin_store_rows table stores oauth2_basic keys as `oauth2_basic_user_user_12345` because 'user_' appears in `user_details[:user_id]`.  I assume this is unintended.

Current table example:
```psql
 id | plugin_name  |              key              | type_name |     value
----+--------------+-------------------------------+-----------+---------------
  3 | oauth2_basic | oauth2_basic_user_user_365518 | JSON      | {"user_id":4}
  4 | oauth2_basic | oauth2_basic_user_user_365517 | JSON      | {"user_id":5}
```

This will fix the key, but in the process will break any existing deployments of this plugin until the maintainers run an update to make the existing keys match.  This might be early enough in the plugin's life to make this change, but on the other hand it's purely aesthetic and will probably be seen by almost nobody, so if it's not worth the risk please disregard.