### PR TITLE
Improvement: downcase the email when searching for an account by email

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -75,7 +75,7 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
     if current_info
       result.user = User.where(id: current_info[:user_id]).first
     elsif SiteSetting.oauth2_email_verified?
-      result.user = User.where(email: result.email).first
+      result.user = User.where(email: Email.downcase(result.email)).first
     end
 
     result.extra_data = { oauth2_basic_user_id: user_details[:user_id] }


### PR DESCRIPTION
Improvement of 2b9869e (FEATURE: If the email is verified, we can use that to find accounts): Downcasing the email which has been got from the OAuth provider, as the email entity is not case-sensitive in Discourse. I've provided more information in the https://meta.discourse.org/t/oauth2-basic-support/33879/31
Thanks!