### PR TITLE
FIX: make work with user_emails migration

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -104,7 +104,7 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
     if current_info
       result.user = User.where(id: current_info[:user_id]).first
     elsif SiteSetting.oauth2_email_verified?
-      result.user = User.where(email: Email.downcase(result.email)).first
+      result.user = User.find_by_email(result.email)
       if result.user && user_details[:user_id]
         ::PluginStore.set("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}", user_id: result.user.id)
       end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+# This is ugly... but it works!
+# Need to load plugin.rb to avoid:
+#
+# NameError:
+#   uninitialized constant OAuth2BasicAuthenticator
+#
+# And need to mock various methods to avoid:
+#
+# NoMethodError:
+#   undefined method `enabled_site_setting' for main:Object
+#
+# etc.
+
+def enabled_site_setting(arg)
+end
+
+def auth_provider(arg)
+end
+
+def register_css(arg)
+end
+
+require_relative '../plugin.rb'
+
+describe OAuth2BasicAuthenticator do
+  context 'after_authenticate' do
+    it 'finds user by email' do
+      authenticator = OAuth2BasicAuthenticator.new('oauth2_basic')
+      user = Fabricate(:user)
+      authenticator.expects(:fetch_user_details).returns(email: user.email)
+      SiteSetting.oauth2_email_verified = true
+      auth = { 'credentials' => { 'token': 'token' },
+               'info' => { id: 'id' },
+               'extra' => {} }
+
+      result = authenticator.after_authenticate(auth)
+
+      expect(result.user).to eq(user)
+    end
+  end
+end


### PR DESCRIPTION
See: https://meta.discourse.org/t/custom-oauth2-fails-for-newly-created-accounts-related-to-user-emails/69406

This should also be backwards compatible with users on Discourse branch not using `user_emails`, as `User.find_by_email` existed before the migration.