### PR TITLE
Add request methods for token and user_json urls

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,7 +5,9 @@ en:
     oauth2_client_secret: 'Client Secret for custom OAuth2'
     oauth2_authorize_url: 'Authorization URL for OAuth2'
     oauth2_token_url: 'Token URL for OAuth2'
+    oauth2_token_url_method: 'Method used to fetch the Token URL'
     oauth2_user_json_url: 'URL to fetch user JSON for OAuth2 (note we replace :id with the id returned by OAuth call and :token with the token id)'
+    oauth2_user_json_url_method: 'Method used to fetch the user JSON URL'
     oauth2_json_user_id_path: 'Path in the OAuth2 User JSON to the user id. eg: user.id'
     oauth2_json_username_path: 'Path in the OAuth2 User JSON to the username. eg: user.username'
     oauth2_json_name_path: "Path in the OAuth2 User JSON to the user's full: user.name.full"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,18 @@ login:
   oauth2_authorize_url: ''
   oauth2_token_url: ''
   oauth2_user_json_url: ''
+  oauth2_token_url_method:
+    default: 'GET'
+    type: enum
+    choices:
+      - GET
+      - POST
+  oauth2_user_json_url_method:
+    default: 'GET'
+    type: enum
+    choices:
+      - GET
+      - POST
   oauth2_json_user_id_path: ''
   oauth2_json_username_path: ''
   oauth2_json_name_path: ''

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,6 +4,9 @@
 # authors: Robin Ward
 # url: https://github.com/discourse/discourse-oauth2-basic
 
+require 'uri'
+require 'net/http'
+
 require_dependency 'auth/oauth2_authenticator.rb'
 
 enabled_site_setting :oauth2_enabled
@@ -32,7 +35,8 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
                         opts[:provider_ignores_state] = false
                         opts[:client_options] = {
                           authorize_url: SiteSetting.oauth2_authorize_url,
-                          token_url: SiteSetting.oauth2_token_url
+                          token_url: SiteSetting.oauth2_token_url,
+                          token_method: SiteSetting.oauth2_token_url_method.downcase.to_sym
                         }
                         opts[:authorize_options] = SiteSetting.oauth2_authorize_options.split("|").map(&:to_sym)
 
@@ -70,10 +74,21 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
 
   def fetch_user_details(token, id)
     user_json_url = SiteSetting.oauth2_user_json_url.sub(':token', token.to_s).sub(':id', id.to_s)
+    user_json_method = SiteSetting.oauth2_user_json_url_method
 
-    log("user_json_url: #{user_json_url}")
+    log("user_json_url: #{user_json_method} #{user_json_url}")
 
-    user_json = JSON.parse(open(user_json_url, 'Authorization' => "Bearer #{token}").read)
+    bearer_token = "Bearer #{token}"
+    user_json_response =
+      if user_json_method.downcase.to_sym == :post
+        Net::HTTP
+          .post_form(URI(user_json_url), { 'Authorization' => bearer_token })
+          .body
+      else
+        open(user_json_url, 'Authorization' => bearer_token).read
+      end
+
+    user_json = JSON.parse(user_json_response)
 
     log("user_json: #{user_json}")
 


### PR DESCRIPTION
Allows specifying a request method for `oauth2_token_url` and `oauth2_user_json_url`. Defaults to `GET`.

Context:

https://meta.discourse.org/t/oauth2-basic-support/33879/66?u=davidmh