### PR TITLE
Add site setting to allow full screen login

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -19,4 +19,4 @@ en:
     oauth2_authorize_options: "When authorizing request these options"
     oauth2_scope: "When authorizing request this scope"
     oauth2_button_title: "The text for the OAuth2 button"
-
+    oauth2_full_screen_login: "Use main browser window instead of popup for login"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,3 +34,6 @@ login:
   oauth2_button_title:
     default: 'with OAuth2'
     client: true
+  oauth2_full_screen_login:
+    default: false
+    client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -149,7 +149,9 @@ end
 auth_provider title_setting: "oauth2_button_title",
               enabled_setting: "oauth2_enabled",
               authenticator: OAuth2BasicAuthenticator.new('oauth2_basic'),
-              message: "OAuth2"
+              message: "OAuth2",
+              full_screen_login_setting: "oauth2_full_screen_login"
+
 
 register_css <<CSS
 


### PR DESCRIPTION
this would give the oauth2-basic plugin an option to use full screen login when combined with this PR https://github.com/discourse/discourse/pull/6180