### PR TITLE
Add override for other info

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,6 +15,7 @@ en:
     oauth2_json_avatar_path: "Path in the Oauth2 User JSON to the user's avatar: user.avatar_url"
     oauth2_email_verified: "Check this if the OAuth2 site has verified the email"
     oauth2_overrides_email: "Override the Discourse email with the remote email on every login"
+    oauth2_overrides_all: "Override other Discourse user information with the remote information on every login"
     oauth2_send_auth_header: "Send the token as an HTTP Authorization header"
     oauth2_debug_auth: "Include rich debugging information in your logs"
     oauth2_authorize_options: "When authorizing request these options"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ login:
   oauth2_json_avatar_path: ''
   oauth2_email_verified: false
   oauth2_overrides_email: false
+  oauth2_overrides_all: false
   oauth2_send_auth_header: true
   oauth2_debug_auth: false
   oauth2_authorize_options:


### PR DESCRIPTION
This adds an option which allows you to require users to use the username given by the oauth provider.