### PR TITLE
Allow provider to set email verification state

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -12,6 +12,7 @@ en:
     oauth2_json_username_path: 'Path in the OAuth2 User JSON to the username. eg: user.username'
     oauth2_json_name_path: "Path in the OAuth2 User JSON to the user's full: user.name.full"
     oauth2_json_email_path: "Path in the OAuth2 User JSON to the user's email: user.email.primary"
+    oauth2_json_email_verified_path: "Path in the OAuth2 User JSON to the user's email verification state: user.email.verified"
     oauth2_json_avatar_path: "Path in the Oauth2 User JSON to the user's avatar: user.avatar_url"
     oauth2_email_verified: "Check this if the OAuth2 site has verified the email"
     oauth2_overrides_email: "Override the Discourse email with the remote email on every login"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,7 @@ login:
   oauth2_json_username_path: ''
   oauth2_json_name_path: ''
   oauth2_json_email_path: ''
+  oauth2_json_email_verified_path: ''
   oauth2_json_avatar_path: ''
   oauth2_email_verified: false
   oauth2_overrides_email: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -104,6 +104,7 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
       json_walk(result, user_json, :username)
       json_walk(result, user_json, :name)
       json_walk(result, user_json, :email)
+      json_walk(result, user_json, :email_verified)
       json_walk(result, user_json, :avatar)
     end
 
@@ -120,14 +121,14 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
     result.name = user_details[:name]
     result.username = user_details[:username]
     result.email = user_details[:email]
-    result.email_valid = result.email.present? && SiteSetting.oauth2_email_verified?
+    result.email_valid = user_details[:email_verified] || (result.email.present? && SiteSetting.oauth2_email_verified?)
     avatar_url = user_details[:avatar]
 
     current_info = ::PluginStore.get("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}")
     if current_info
       result.user = User.where(id: current_info[:user_id]).first
       result.user&.update!(email: result.email) if SiteSetting.oauth2_overrides_email && result.email
-    elsif SiteSetting.oauth2_email_verified?
+    elsif user_details[:email_verified] || SiteSetting.oauth2_email_verified?
       result.user = User.find_by_email(result.email)
       if result.user && user_details[:user_id]
         ::PluginStore.set("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}", user_id: result.user.id)

--- a/plugin.rb
+++ b/plugin.rb
@@ -121,14 +121,14 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
     result.name = user_details[:name]
     result.username = user_details[:username]
     result.email = user_details[:email]
-    result.email_valid = user_details[:email_verified] || (result.email.present? && SiteSetting.oauth2_email_verified?)
+    result.email_valid = result.email.present? && (user_details[:email_verified] || SiteSetting.oauth2_email_verified?)
     avatar_url = user_details[:avatar]
 
     current_info = ::PluginStore.get("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}")
     if current_info
       result.user = User.where(id: current_info[:user_id]).first
       result.user&.update!(email: result.email) if SiteSetting.oauth2_overrides_email && result.email
-    elsif user_details[:email_verified] || SiteSetting.oauth2_email_verified?
+    elsif result.email_valid
       result.user = User.find_by_email(result.email)
       if result.user && user_details[:user_id]
         ::PluginStore.set("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}", user_id: result.user.id)

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -71,6 +71,21 @@ describe OAuth2BasicAuthenticator do
       expect(result.user.email).to eq("newemail@example.com")
     end
 
+    it 'validates user email if provider has verified' do
+      SiteSetting.oauth2_email_verified = false
+
+      # Check it's working
+      authenticator.stubs(:fetch_user_details).returns(email: user.email, email_verified: true)
+      result = authenticator.after_authenticate(auth)
+      expect(result.email_valid).to eq(true)
+
+      # Check it doesn't interfere with the site setting
+      SiteSetting.oauth2_email_verified = true
+      authenticator.stubs(:fetch_user_details).returns(email: user.email, email_verified: false)
+      result = authenticator.after_authenticate(auth)
+      expect(result.email_valid).to eq(true)
+    end
+
     context 'avatar downloading' do
       before { SiteSetting.queue_jobs = true }
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -79,6 +79,10 @@ describe OAuth2BasicAuthenticator do
       result = authenticator.after_authenticate(auth)
       expect(result.email_valid).to eq(true)
 
+      authenticator.stubs(:fetch_user_details).returns(email: user.email, email_verified: nil)
+      result = authenticator.after_authenticate(auth)
+      expect(result.email_valid).to eq(false)
+
       # Check it doesn't interfere with the site setting
       SiteSetting.oauth2_email_verified = true
       authenticator.stubs(:fetch_user_details).returns(email: user.email, email_verified: false)


### PR DESCRIPTION
This allows a provider to set a user's email verification state by identifying the relevant email verification property in the user object. An example of such is: https://developers.digitalocean.com/documentation/v2/#get-user-information "email_verified"