### PR TITLE
Use token callback user details

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,6 +6,9 @@ en:
     oauth2_authorize_url: 'Authorization URL for OAuth2'
     oauth2_token_url: 'Token URL for OAuth2'
     oauth2_token_url_method: 'Method used to fetch the Token URL'
+    oauth2_callback_user_id_path: 'Path in the token response to the user id. eg: params.info.uuid'
+    oauth2_callback_user_info_paths: 'Paths in the token response to other user properties. Supported properties are name, username, email, email_verfied and avatar. Format is property:path, eg: name:params.info.name'
+    oauth2_fetch_user_details: "Fetch user JSON for OAuth2"
     oauth2_user_json_url: 'URL to fetch user JSON for OAuth2 (note we replace :id with the id returned by OAuth call and :token with the token id)'
     oauth2_user_json_url_method: 'Method used to fetch the user JSON URL'
     oauth2_json_user_id_path: 'Path in the OAuth2 User JSON to the user id. eg: user.id'
@@ -22,3 +25,6 @@ en:
     oauth2_scope: "When authorizing request this scope"
     oauth2_button_title: "The text for the OAuth2 button"
     oauth2_full_screen_login: "Use main browser window instead of popup for login"
+
+    errors:
+      oauth2_fetch_user_details: "oauth2_callback_user_id_path must be present to disable oauth2_fetch_user_details"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,13 +6,20 @@ login:
   oauth2_client_secret: ''
   oauth2_authorize_url: ''
   oauth2_token_url: ''
-  oauth2_user_json_url: ''
   oauth2_token_url_method:
     default: 'POST'
     type: enum
     choices:
       - GET
       - POST
+  oauth2_callback_user_id_path: ''
+  oauth2_callback_user_info_paths:
+    type: list
+    default: 'id'
+  oauth2_fetch_user_details:
+    default: true
+    validator: "Oauth2FetchUserDetailsValidator"
+  oauth2_user_json_url: ''
   oauth2_user_json_url_method:
     default: 'GET'
     type: enum

--- a/lib/validators/oauth2_basic/oauth2_fetch_user_details_validator.rb
+++ b/lib/validators/oauth2_basic/oauth2_fetch_user_details_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Oauth2FetchUserDetailsValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val == "t"
+    SiteSetting.oauth2_callback_user_id_path.length > 0
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.oauth2_fetch_user_details")
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -140,13 +140,13 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
     result = Auth::Result.new
     token = auth['credentials']['token']
 
-    user_details = Hash.new
+    user_details = {}
     user_details[:user_id] = auth['uid'] if auth['uid']
     ['name', 'username', 'email', 'email_verified', 'avatar'].each do |key|
       user_details[key.to_sym] = auth['info'][key] if auth['info'][key]
     end
 
-    if SiteSetting.oauth2_fetch_user_details
+    if SiteSetting.oauth2_fetch_user_details?
       fetched_user_details = fetch_user_details(token, auth['uid'])
       user_details.merge!(fetched_user_details)
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -12,14 +12,37 @@ enabled_site_setting :oauth2_enabled
 
 class ::OmniAuth::Strategies::Oauth2Basic < ::OmniAuth::Strategies::OAuth2
   option :name, "oauth2_basic"
+
+  uid do
+    if path = SiteSetting.oauth2_callback_user_id_path.split('.')
+      recurse(access_token, [*path]) if path.present?
+    end
+  end
+
   info do
-    {
-      id: access_token['id']
-    }
+    if paths = SiteSetting.oauth2_callback_user_info_paths.split('|')
+      result = Hash.new
+      paths.each do |p|
+        segments = p.split(':')
+        if segments.length == 2
+          key = segments.first
+          path = [*segments.last.split('.')]
+          result[key] = recurse(access_token, path)
+        end
+      end
+      result
+    end
   end
 
   def callback_url
     Discourse.base_url_no_prefix + script_name + callback_path
+  end
+
+  def recurse(obj, keys)
+    return nil if !obj
+    k = keys.shift
+    result = obj.respond_to?(k) ? obj.send(k) : obj[k]
+    keys.empty? ? result : recurse(result, keys)
   end
 end
 
@@ -112,11 +135,21 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
   end
 
   def after_authenticate(auth)
-    log("after_authenticate response: \n\ncreds: #{auth['credentials'].to_hash}\ninfo: #{auth['info'].to_hash}\nextra: #{auth['extra'].to_hash}")
+    log("after_authenticate response: \n\ncreds: #{auth['credentials'].to_hash}\nuid: #{auth['uid']}\ninfo: #{auth['info'].to_hash}\nextra: #{auth['extra'].to_hash}")
 
     result = Auth::Result.new
     token = auth['credentials']['token']
-    user_details = fetch_user_details(token, auth['info'][:id])
+
+    user_details = Hash.new
+    user_details[:user_id] = auth['uid'] if auth['uid']
+    ['name', 'username', 'email', 'email_verified', 'avatar'].each do |key|
+      user_details[key.to_sym] = auth['info'][key] if auth['info'][key]
+    end
+
+    if SiteSetting.oauth2_fetch_user_details
+      fetched_user_details = fetch_user_details(token, auth['uid'])
+      user_details.merge!(fetched_user_details)
+    end
 
     result.name = user_details[:name]
     result.username = user_details[:username]
@@ -171,3 +204,5 @@ register_css <<CSS
   }
 
 CSS
+
+load File.expand_path("../lib/validators/oauth2_basic/oauth2_fetch_user_details_validator.rb", __FILE__)


### PR DESCRIPTION
A number of OAuth2 implementations include details about the user in the response to an access token request. Here are some examples:
- [DigitalOcean](https://developers.digitalocean.com/documentation/oauth/#request-access-token): name, email and user id
- [Instagram](https://www.instagram.com/developer/authentication/): user id, username, name and profile picture (avatar)
- [FitBit](https://dev.fitbit.com/build/reference/web-api/oauth2/#access-token-request): user id
- [Asana](https://asana.com/developers/documentation/getting-started/auth#token-exchange): user id, name, email

In some cases (somewhat surprisingly) this includes information about the user that is not available in a user endpoint request, for example the DigitalOcean API provides a user's name in the access token response, but not in the response to a request for account details.

The omniauth library anticipates this behviour, which is why the[ AuthHash mapping in the callback phase](https://github.com/omniauth/omniauth/wiki/Strategy-Contribution-Guide#defining-the-callback-phase) provides a ``uid`` and ``info`` block. 

The current implementation of omniauth in this plugin is slightly flawed insofar as it sets a static 'id' field in the ``info`` block of the callback phase. Ideally the user id on the provider should be mapped in the ``uid`` block, and it's mapping changes between providers (i.e. it will not always be present at ``access_token['id']``).

If the user information provided in the access token callback is sufficient (i.e. it includes a user_id), this obviates the need for a subsequent request to a user endpoint.

This PR does three things:

1. Provides a way map both the user and and user info returned in an access token response to the ``uid`` and ``info`` blocks in the omniauth callback phase. This can be set on a per-provider basis using the ``oauth2_callback_user_id_path`` and ``oauth2_callback_user_info_paths`` site settings.

2. Applies any user details retrived in the callback phase mapping to the user details used in after_authenticate.

3. Allows for the disabling of the subsequent user endpoint request if the callback phase provides, at a minimum, a user id from the oauth2 provider (i.e. has a mapping referred to in 1).

This has been successfully tested with all of the above OAuth2 implementations, i.e. DigitialOcean, Instagram, FitBit and Asana.

Note that existing behavior and implementations will be unaffected by these changes