### PR TITLE
Move to ManagedAuthenticator

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -28,6 +28,7 @@ en:
     oauth2_scope: "When authorizing request this scope"
     oauth2_button_title: "The text for the OAuth2 button"
     oauth2_full_screen_login: "Use main browser window instead of popup for login"
+    oauth2_allow_association_change: Allow users to disconnect and reconnect their Discourse accounts from the OAuth2 provider
 
     errors:
       oauth2_fetch_user_details: "oauth2_callback_user_id_path must be present to disable oauth2_fetch_user_details"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,3 +46,5 @@ login:
   oauth2_full_screen_login:
     default: false
     client: true
+  oauth2_allow_association_change:
+    default: false

--- a/db/migrate/20190724055909_move_to_managed_authenticator.rb
+++ b/db/migrate/20190724055909_move_to_managed_authenticator.rb
@@ -1,0 +1,24 @@
+class MoveToManagedAuthenticator < ActiveRecord::Migration[5.2]
+  def change
+    ::PluginStoreRow.where(plugin_name: 'oauth2_basic').each do |record|
+      provider_uid = record.key.split('_').last
+      
+      begin
+        value_hash = JSON.parse(record.value)
+        user_id = value_hash["user_id"]
+      rescue JSON::ParserError
+        nil
+      end
+      
+      if provider_uid && user_id
+        UserAssociatedAccount.create(
+          provider_name: 'oauth2_basic',
+          provider_uid: provider_uid,
+          user_id: user_id
+        )
+      end
+      
+      record.destroy
+    end
+  end
+end

--- a/db/migrate/20190724055909_move_to_managed_authenticator.rb
+++ b/db/migrate/20190724055909_move_to_managed_authenticator.rb
@@ -1,24 +1,20 @@
 class MoveToManagedAuthenticator < ActiveRecord::Migration[5.2]
-  def change
-    ::PluginStoreRow.where(plugin_name: 'oauth2_basic').each do |record|
-      provider_uid = record.key.split('_').last
-      
-      begin
-        value_hash = JSON.parse(record.value)
-        user_id = value_hash["user_id"]
-      rescue JSON::ParserError
-        nil
-      end
-      
-      if provider_uid && user_id
-        UserAssociatedAccount.create(
-          provider_name: 'oauth2_basic',
-          provider_uid: provider_uid,
-          user_id: user_id
-        )
-      end
-      
-      record.destroy
-    end
+  def up
+    execute <<~SQL
+    INSERT INTO user_associated_accounts (
+      provider_name,
+      provider_uid,
+      user_id,
+      created_at,
+      updated_at
+    ) SELECT
+      'oauth2_basic',
+      replace(key, 'oauth2_basic_user_', ''),
+      (value::json->>'user_id')::integer,
+      CURRENT_TIMESTAMP,
+      CURRENT_TIMESTAMP
+    FROM plugin_store_rows
+    WHERE plugin_name = 'oauth2_basic'
+    SQL
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -168,7 +168,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       end
     end
         
-    super(auth.with_indifferent_access)
+    super(auth)
   end
 
   def enabled?

--- a/plugin.rb
+++ b/plugin.rb
@@ -141,7 +141,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
   end
   
   def primary_email_verified?(auth)
-    ActiveModel::Type::Boolean.new.cast(auth['info']['email_verified']) ||
+    auth['info']['email_verified'] ||
     SiteSetting.oauth2_email_verified
   end
   

--- a/plugin.rb
+++ b/plugin.rb
@@ -177,7 +177,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
 end
 
 auth_provider title_setting: "oauth2_button_title",
-              authenticator: OAuth2BasicAuthenticator.new(),
+              authenticator: OAuth2BasicAuthenticator.new,
               message: "OAuth2",
               full_screen_login_setting: "oauth2_full_screen_login"
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -51,6 +51,14 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
     'oauth2_basic'
   end
 
+  def can_revoke?
+    SiteSetting.oauth2_allow_association_change
+  end
+
+  def can_connect_existing_user?
+    SiteSetting.oauth2_allow_association_change
+  end
+
   def register_middleware(omniauth)
     omniauth.provider :oauth2_basic,
                       name: name,

--- a/plugin.rb
+++ b/plugin.rb
@@ -122,7 +122,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
     bearer_token = "Bearer #{token}"
     connection = Excon.new(
       user_json_url,
-      :headers => { 'Authorization' => bearer_token, 'Accept' => 'application/json' }
+      headers: { 'Authorization' => bearer_token, 'Accept' => 'application/json' }
     )
     user_json_response = connection.request(method: user_json_method)
 
@@ -147,12 +147,12 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       nil
     end
   end
-  
+
   def primary_email_verified?(auth)
     auth['info']['email_verified'] ||
     SiteSetting.oauth2_email_verified
   end
-  
+
   def always_update_user_email?
     SiteSetting.oauth2_overrides_email
   end
@@ -175,7 +175,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
         return result
       end
     end
-        
+
     super(auth)
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -149,7 +149,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
     SiteSetting.oauth2_overrides_email
   end
 
-  def after_authenticate(auth)
+  def after_authenticate(auth, existing_account: nil)
     log("after_authenticate response: \n\ncreds: #{auth['credentials'].to_hash}\nuid: #{auth['uid']}\ninfo: #{auth['info'].to_hash}\nextra: #{auth['extra'].to_hash}")
 
     if SiteSetting.oauth2_fetch_user_details?

--- a/plugin.rb
+++ b/plugin.rb
@@ -176,7 +176,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       end
     end
 
-    super(auth)
+    super(auth, existing_account: existing_account)
   end
 
   def enabled?

--- a/plugin.rb
+++ b/plugin.rb
@@ -46,10 +46,14 @@ class ::OmniAuth::Strategies::Oauth2Basic < ::OmniAuth::Strategies::OAuth2
   end
 end
 
-class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
+class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
+  def name
+    'oauth2_basic'
+  end
+
   def register_middleware(omniauth)
     omniauth.provider :oauth2_basic,
-                      name: 'oauth2_basic',
+                      name: name,
                       setup: lambda { |env|
                         opts = env['omniauth.strategy'].options
                         opts[:client_id] = SiteSetting.oauth2_client_id
@@ -135,63 +139,36 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
       nil
     end
   end
+  
+  def primary_email_verified?(auth)
+    ActiveModel::Type::Boolean.new.cast(auth['info']['email_verified']) ||
+    SiteSetting.oauth2_email_verified
+  end
+  
+  def always_update_user_email?
+    SiteSetting.oauth2_overrides_email
+  end
 
   def after_authenticate(auth)
     log("after_authenticate response: \n\ncreds: #{auth['credentials'].to_hash}\nuid: #{auth['uid']}\ninfo: #{auth['info'].to_hash}\nextra: #{auth['extra'].to_hash}")
 
-    result = Auth::Result.new
-    token = auth['credentials']['token']
-
-    user_details = {}
-    user_details[:user_id] = auth['uid'] if auth['uid']
-    ['name', 'username', 'email', 'email_verified', 'avatar'].each do |key|
-      user_details[key.to_sym] = auth['info'][key] if auth['info'][key]
-    end
-
     if SiteSetting.oauth2_fetch_user_details?
-      if fetched_user_details = fetch_user_details(token, auth['uid'])
-        user_details.merge!(fetched_user_details)
+      if fetched_user_details = fetch_user_details(auth['credentials']['token'], auth['uid'])
+        auth['uid'] = fetched_user_details[:user_id] if fetched_user_details[:user_id]
+        auth['info']['nickname'] = fetched_user_details[:username] if fetched_user_details[:username]
+        auth['info']['image'] = fetched_user_details[:avatar] if fetched_user_details[:avatar]
+        ['name', 'email', 'email_verified'].each do |property|
+          auth['info'][property] = fetched_user_details[property.to_sym] if fetched_user_details[property.to_sym]
+        end
       else
+        result = Auth::Result.new
         result.failed = true
         result.failed_reason = I18n.t("login.authenticator_error_fetch_user_details")
         return result
       end
     end
-
-    result.name = user_details[:name]
-    result.username = user_details[:username]
-    result.email = user_details[:email]
-    result.email_valid = result.email.present? && (user_details[:email_verified] || SiteSetting.oauth2_email_verified?)
-    avatar_url = user_details[:avatar]
-
-    current_info = ::PluginStore.get("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}")
-    if current_info
-      result.user = User.where(id: current_info[:user_id]).first
-      result.user&.update!(email: result.email) if SiteSetting.oauth2_overrides_email && result.email
-    elsif result.email_valid
-      result.user = User.find_by_email(result.email)
-      if result.user && user_details[:user_id]
-        ::PluginStore.set("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}", user_id: result.user.id)
-      end
-    end
-
-    download_avatar(result.user, avatar_url)
-
-    result.extra_data = { oauth2_basic_user_id: user_details[:user_id], avatar_url: avatar_url }
-    result
-  end
-
-  def after_create_account(user, auth)
-    ::PluginStore.set("oauth2_basic", "oauth2_basic_user_#{auth[:extra_data][:oauth2_basic_user_id]}", user_id: user.id)
-    download_avatar(user, auth[:extra_data][:avatar_url])
-  end
-
-  def download_avatar(user, avatar_url)
-    Jobs.enqueue(:download_avatar_from_url,
-      url: avatar_url,
-      user_id: user.id,
-      override_gravatar: SiteSetting.sso_overrides_avatar
-    ) if user && avatar_url.present?
+        
+    super(auth.with_indifferent_access)
   end
 
   def enabled?
@@ -200,7 +177,7 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
 end
 
 auth_provider title_setting: "oauth2_button_title",
-              authenticator: OAuth2BasicAuthenticator.new('oauth2_basic'),
+              authenticator: OAuth2BasicAuthenticator.new(),
               message: "OAuth2",
               full_screen_login_setting: "oauth2_full_screen_login"
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -33,11 +33,11 @@ describe OAuth2BasicAuthenticator do
     let(:authenticator) { OAuth2BasicAuthenticator.new }
 
     let(:auth) do
-      { 'provider' => 'oauth2_basic',
+      OmniAuth::AuthHash.new({ 'provider' => 'oauth2_basic',
         'credentials' => { 'token': 'token' },
         'uid' => '123456789',
         'info' => { id: 'id' },
-        'extra' => {} }.with_indifferent_access
+        'extra' => {} })
     end
 
     before(:each) do
@@ -235,7 +235,7 @@ describe OAuth2BasicAuthenticator do
     let(:authenticator) { OAuth2BasicAuthenticator.new }
 
     let(:auth) do
-      {
+      OmniAuth::AuthHash.new({
         'provider' => 'oauth2_basic',
         'credentials' => {
           'token' => 'token'
@@ -246,7 +246,7 @@ describe OAuth2BasicAuthenticator do
           "email" => 'sammy@digitalocean.com'
         },
         'extra' => {}
-      }.with_indifferent_access
+      })
     end
 
     let(:access_token) do

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -37,7 +37,7 @@ describe OAuth2BasicAuthenticator do
         'credentials' => { 'token': 'token' },
         'uid' => '123456789',
         'info' => { id: 'id' },
-        'extra' => {} }
+        'extra' => {} }.with_indifferent_access
     end
 
     before(:each) do
@@ -246,7 +246,7 @@ describe OAuth2BasicAuthenticator do
           "email" => 'sammy@digitalocean.com'
         },
         'extra' => {}
-      }
+      }.with_indifferent_access
     end
 
     let(:access_token) do

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -30,7 +30,7 @@ require_relative '../plugin.rb'
 describe OAuth2BasicAuthenticator do
   context 'after_authenticate' do
     let(:user) { Fabricate(:user) }
-    let(:authenticator) { OAuth2BasicAuthenticator.new() }
+    let(:authenticator) { OAuth2BasicAuthenticator.new }
 
     let(:auth) do
       { 'provider' => 'oauth2_basic',
@@ -194,7 +194,7 @@ describe OAuth2BasicAuthenticator do
   end
 
   it 'can walk json' do
-    authenticator = OAuth2BasicAuthenticator.new()
+    authenticator = OAuth2BasicAuthenticator.new
     json_string = '{"user":{"id":1234,"email":{"address":"test@example.com"}}}'
     SiteSetting.oauth2_json_email_path = 'user.email.address'
     result = authenticator.json_walk({}, JSON.parse(json_string), :email)
@@ -203,7 +203,7 @@ describe OAuth2BasicAuthenticator do
   end
 
   it 'can walk json that contains an array' do
-    authenticator = OAuth2BasicAuthenticator.new()
+    authenticator = OAuth2BasicAuthenticator.new
     json_string = '{"email":"test@example.com","identities":[{"user_id":"123456789","provider":"auth0","isSocial":false}]}'
     SiteSetting.oauth2_json_user_id_path = 'identities.[].user_id'
     result = authenticator.json_walk({}, JSON.parse(json_string), :user_id)
@@ -212,7 +212,7 @@ describe OAuth2BasicAuthenticator do
   end
 
   it 'can walk json and handle an empty array' do
-    authenticator = OAuth2BasicAuthenticator.new()
+    authenticator = OAuth2BasicAuthenticator.new
     json_string = '{"email":"test@example.com","identities":[]}'
     SiteSetting.oauth2_json_user_id_path = 'identities.[].user_id'
     result = authenticator.json_walk({}, JSON.parse(json_string), :user_id)
@@ -221,7 +221,7 @@ describe OAuth2BasicAuthenticator do
   end
 
   it 'can walk json and download avatar' do
-    authenticator = OAuth2BasicAuthenticator.new()
+    authenticator = OAuth2BasicAuthenticator.new
     json_string = '{"user":{"avatar":"http://example.com/1.png"}}'
     SiteSetting.oauth2_json_avatar_path = 'user.avatar'
     result = authenticator.json_walk({}, JSON.parse(json_string), :avatar)
@@ -232,7 +232,7 @@ describe OAuth2BasicAuthenticator do
   context 'token_callback' do
     let(:user) { Fabricate(:user) }
     let(:strategy) { OmniAuth::Strategies::Oauth2Basic.new({}) }
-    let(:authenticator) { OAuth2BasicAuthenticator.new() }
+    let(:authenticator) { OAuth2BasicAuthenticator.new }
 
     let(:auth) do
       {

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -178,7 +178,7 @@ describe OAuth2BasicAuthenticator do
         expect {
           auth_result = authenticator.after_authenticate(auth)
         }.to change { job_klass.jobs.count }.by(0)
-        
+
         expect {
           authenticator.after_create_account(user, auth_result.session_data)
         }.to change { job_klass.jobs.count }.by(1)


### PR DESCRIPTION
This PR follows up on the [discussion here](https://meta.discourse.org/t/oauth2-basic-support/33879/187?u=angus). It does two things:

1. Turns the ``OAuth2BasicAuthenticator`` class into an extension of ``Auth::ManagedAuthenticator`` instead of ``Auth::OAuth2Authenticator``. Mostly this involves moving the after_authenticate result and user handling to the standardised ``Auth::ManagedAuthenticator`` after_authenticate method.

2. Migrates the existing storage of associated user details from ``PluginStore`` to ``UserAssoicatedAccount``.

The existing tests are all passing and existing implementations should not be affected.