### PR TITLE
allow the json path walk method to parse array indexes

### DIFF
--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -195,6 +195,15 @@ describe OAuth2BasicAuthenticator do
     expect(result).to eq nil
   end
 
+  it 'can walk json and find values by index in an array' do
+    authenticator = OAuth2BasicAuthenticator.new
+    json_string = '{"emails":[{"value":"test@example.com"},{"value":"test2@example.com"}]}'
+    SiteSetting.oauth2_json_email_path = 'emails[1].value'
+    result = authenticator.json_walk({}, JSON.parse(json_string), :email)
+
+    expect(result).to eq "test2@example.com"
+  end
+
   it 'can walk json and download avatar' do
     authenticator = OAuth2BasicAuthenticator.new
     json_string = '{"user":{"avatar":"http://example.com/1.png"}}'


### PR DESCRIPTION
Hi!

The way the old json walk worked prevented us from pulling the email address out of the json response our oauth provider sent back. The format looked something like 
```
{ "emails" : 
   [ { "value" : "theemail@adress.com"} ]
}
```
The old way would return { "value" : "theemail@address.com"}, where of course we only wanted the value of "value".
It is changed so now you can write your path like
`emails[index].value`
to get it, or if you do `emails.value` it will still default to an index of 0 so as not to break old paths. 