### PR TITLE
FEATURE: Allow using a different authorize_url for signup

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,7 @@ en:
     oauth2_client_id: 'Client ID for custom OAuth2'
     oauth2_client_secret: 'Client Secret for custom OAuth2'
     oauth2_authorize_url: 'Authorization URL for OAuth2'
+    oauth2_authorize_signup_url: '(optional) Alternate authorization URL used when the "Sign Up" button is used'
     oauth2_token_url: 'Token URL for OAuth2'
     oauth2_token_url_method: 'Method used to fetch the Token URL'
     oauth2_callback_user_id_path: 'Path in the token response to the user id. eg: params.info.uuid'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ login:
   oauth2_client_id: ''
   oauth2_client_secret: ''
   oauth2_authorize_url: ''
+  oauth2_authorize_signup_url: ''
   oauth2_token_url: ''
   oauth2_token_url_method:
     default: 'POST'

--- a/plugin.rb
+++ b/plugin.rb
@@ -101,6 +101,11 @@ class ::OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
                         }
                         opts[:authorize_options] = SiteSetting.oauth2_authorize_options.split("|").map(&:to_sym)
 
+                        if SiteSetting.oauth2_authorize_signup_url.present? &&
+                            ActionDispatch::Request.new(env).params["signup"].present?
+                          opts[:client_options][:authorize_url] = SiteSetting.oauth2_authorize_signup_url
+                        end
+
                         if SiteSetting.oauth2_send_auth_header? && SiteSetting.oauth2_send_auth_body?
                           # For maximum compatibility we include both header and body auth by default
                           # This is a little unusual, and utilising multiple authentication methods


### PR DESCRIPTION
If specified, the oauth2_authorize_signup_url will be used when the user starts the auth flow via the 'sign up' buttons in the UI. If not specified, the regular authorize_url continues to be used.