### PR TITLE
FEATURE: Handle invalid email_verified data from identity provider

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -237,8 +237,11 @@ class ::OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
   end
 
   def primary_email_verified?(auth)
-    auth['info']['email_verified'] ||
-    SiteSetting.oauth2_email_verified
+    return true if SiteSetting.oauth2_email_verified
+    verified = auth['info']['email_verified']
+    verified = true if verified == "true"
+    verified = false if verified == "false"
+    verified
   end
 
   def always_update_user_email?

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -69,6 +69,17 @@ describe OAuth2BasicAuthenticator do
       expect(result.email_valid).to eq(true)
     end
 
+    it 'handles true/false strings from identity provider' do
+      SiteSetting.oauth2_email_verified = false
+      authenticator.stubs(:fetch_user_details).returns(email: user.email, email_verified: 'true')
+      result = authenticator.after_authenticate(auth)
+      expect(result.email_valid).to eq(true)
+
+      authenticator.stubs(:fetch_user_details).returns(email: user.email, email_verified: 'false')
+      result = authenticator.after_authenticate(auth)
+      expect(result.email_valid).to eq(false)
+    end
+
     context "fetch_user_details" do
       before(:each) do
         SiteSetting.oauth2_fetch_user_details = true


### PR DESCRIPTION
Some identity providers send email_verfied as a 'true'/'false' string, not a boolean. (e.g. this bug in Auth0: https://community.auth0.com/t/27553)

This commit adds automatic handling for this case, so that the string is automatically converted into a real boolean.