### PR TITLE
Hide the `oauth2_disable_csrf` setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,3 +49,4 @@ login:
     default: false
   oauth2_disable_csrf:
     default: false
+    hidden: true


### PR DESCRIPTION
It can be useful for homegrown CSRF setups or while debugging but it is
not secure and should only be used if you really know what you're doing.