### PR TITLE
Update spec to be compliant with ``after_create_account`` expectations

### DIFF
--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -191,7 +191,7 @@ describe OAuth2BasicAuthenticator do
         }.to change { job_klass.jobs.count }.by(0)
 
         expect {
-          authenticator.after_create_account(user, auth_result.session_data)
+          authenticator.after_create_account(user, auth_result)
         }.to change { job_klass.jobs.count }.by(1)
 
         job_args = job_klass.jobs.last['args'].first


### PR DESCRIPTION
``after_create_account`` expects an instance of ``Auth::Result`` as the second arg. Passing the session data hash instead was previously fine as no logic in ``after_create_account`` used instance methods. See further: https://github.com/discourse/discourse/pull/14835#discussion_r755135921