### PR TITLE
DEV: Make overrides_email an integration spec

### DIFF
--- a/spec/integration/overrides_email_spec.rb
+++ b/spec/integration/overrides_email_spec.rb
@@ -30,7 +30,7 @@ describe "OAuth2 Overrides Email", type: :request do
     )
   end
 
-  it 'updates user email if enabled' do
+  it "doesn't update email by default" do
     expect(user.reload.email).to eq(initial_email)
 
     get "/auth/oauth2_basic/callback"
@@ -38,7 +38,9 @@ describe "OAuth2 Overrides Email", type: :request do
     expect(session[:current_user_id]).to eq(user.id)
 
     expect(user.reload.email).to eq(initial_email)
+  end
 
+  it 'updates user email if enabled' do
     SiteSetting.oauth2_overrides_email = true
 
     get "/auth/oauth2_basic/callback"

--- a/spec/integration/overrides_email_spec.rb
+++ b/spec/integration/overrides_email_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "OAuth2 Overrides Email", type: :request do
+  fab!(:initial_email) { "initial@example.com" }
+  fab!(:new_email) { "new@example.com" }
+  fab!(:user) { Fabricate(:user, email: initial_email) }
+  fab!(:uac) { UserAssociatedAccount.create!(user: user, provider_name: "oauth2_basic", provider_uid: "12345") }
+
+  before do
+    SiteSetting.oauth2_enabled = true
+    SiteSetting.oauth2_callback_user_id_path = "uid"
+    SiteSetting.oauth2_fetch_user_details = false
+    SiteSetting.oauth2_email_verified = true
+
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:oauth2_basic] = OmniAuth::AuthHash.new(
+      provider: 'oauth2_basic',
+      uid: '12345',
+      info: OmniAuth::AuthHash::InfoHash.new(
+        email: new_email
+      ),
+      extra: {
+        raw_info: OmniAuth::AuthHash.new(
+          email_verified: true
+        )
+      },
+      credentials: OmniAuth::AuthHash.new
+    )
+  end
+
+  it 'updated user email if enabled' do
+    expect(user.reload.email).to eq(initial_email)
+
+    get "/auth/oauth2_basic/callback"
+    expect(response.status).to eq(302)
+    expect(session[:current_user_id]).to eq(user.id)
+
+    expect(user.reload.email).to eq(initial_email)
+
+    SiteSetting.oauth2_overrides_email = true
+
+    get "/auth/oauth2_basic/callback"
+    expect(response.status).to eq(302)
+    expect(session[:current_user_id]).to eq(user.id)
+
+    expect(user.reload.email).to eq(new_email)
+  end
+end

--- a/spec/integration/overrides_email_spec.rb
+++ b/spec/integration/overrides_email_spec.rb
@@ -30,7 +30,7 @@ describe "OAuth2 Overrides Email", type: :request do
     )
   end
 
-  it 'updated user email if enabled' do
+  it 'updates user email if enabled' do
     expect(user.reload.email).to eq(initial_email)
 
     get "/auth/oauth2_basic/callback"

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -25,29 +25,6 @@ describe OAuth2BasicAuthenticator do
       expect(result.user).to eq(user)
     end
 
-    it 'updated user email if enabled' do
-      authenticator.stubs(:fetch_user_details).returns(email: user.email, user_id: 'id')
-
-      # Create association
-      result = authenticator.after_authenticate(auth)
-      expect(result.user).to eq(user)
-
-      # Change user email on remote system
-      old_email = user.email
-      authenticator.stubs(:fetch_user_details).returns(email: "newemail@example.com", user_id: 'id')
-
-      # Login again - no change
-      result = authenticator.after_authenticate(auth)
-      expect(result.user).to eq(user)
-      expect(result.user.email).to eq(old_email)
-
-      # Enable site setting
-      SiteSetting.oauth2_overrides_email = true
-      result = authenticator.after_authenticate(auth)
-      expect(result.user).to eq(user)
-      expect(result.user.email).to eq("newemail@example.com")
-    end
-
     it 'validates user email if provider has verified' do
       SiteSetting.oauth2_email_verified = false
       authenticator.stubs(:fetch_user_details).returns(email: user.email, email_verified: true)


### PR DESCRIPTION
We're moving the location of the email-overriding logic in https://github.com/discourse/discourse/pull/15378, which makes the old unit test in this plugin fail. This commit makes it an integration test, so that it's more robust against core changes, and will continue to pass before and after the core changes.