### PR TITLE
DEV: Remove unnecessary require

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -6,8 +6,6 @@
 # authors: Robin Ward
 # url: https://github.com/discourse/discourse-oauth2-basic
 
-require_dependency 'auth/oauth2_authenticator.rb'
-
 enabled_site_setting :oauth2_enabled
 
 class ::OmniAuth::Strategies::Oauth2Basic < ::OmniAuth::Strategies::OAuth2


### PR DESCRIPTION
As we’re upgrading Discourse to Rails 7+, we’re also renaming and moving some files to better follow Rails conventions on that matter.

The current `require_dependency` call prevents us to do that and is not necessary as the file referenced here is part of the autoload path.

---

For reference: https://github.com/discourse/discourse/pull/15649