### PR TITLE
DEV: Replace deprecated queue_jobs site setting in tests

### DIFF
--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -128,7 +128,7 @@ describe OAuth2BasicAuthenticator do
 
     describe "avatar downloading" do
       before do
-        SiteSetting.queue_jobs = true
+        Jobs.run_later!
         SiteSetting.oauth2_fetch_user_details = true
         SiteSetting.oauth2_email_verified = true
       end


### PR DESCRIPTION
### What is this change?

The `#queue_jobs=` method on site settings has been [deprecated](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) and replaced by `Jobs.run_later!` and `Jobs.run_immediately!`. This PR replaces usages in this plugin so we can remove the fallback in core.

The fallback used in core for reference:

https://github.com/discourse/discourse/blob/main/app/models/site_setting.rb#L109-L115