### PR TITLE
FIX: do not attempt to fetch user JSON if URL is not set

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -296,7 +296,7 @@ class ::OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       #{auth["extra"].to_hash.to_yaml}
     LOG
 
-    if SiteSetting.oauth2_fetch_user_details?
+    if SiteSetting.oauth2_fetch_user_details? && SiteSetting.oauth2_user_json_url.present?
       if fetched_user_details = fetch_user_details(auth["credentials"]["token"], auth["uid"])
         auth["uid"] = fetched_user_details[:user_id] if fetched_user_details[:user_id]
         auth["info"]["nickname"] = fetched_user_details[:username] if fetched_user_details[

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 describe OAuth2BasicAuthenticator do
   describe "after_authenticate" do
+    before { SiteSetting.oauth2_user_json_url = "https://provider.com/user" }
+
     let(:user) { Fabricate(:user) }
     let(:authenticator) { OAuth2BasicAuthenticator.new }
 


### PR DESCRIPTION
It is a configuration error to set `oauth2_fetch_user_details` to true but leave `oauth2_user_json_url` empty.

Before, this resulted in an unhandled exception in core. Now it is checked for here.