### PR TITLE
Add support for PUT verb for auth token URL

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,7 @@ login:
     choices:
       - GET
       - POST
+      - PUT
   oauth2_callback_user_id_path: ""
   oauth2_callback_user_info_paths:
     type: list


### PR DESCRIPTION
Some APIs require PUT for this call instead of the existing GET or POST options.