### PR TITLE
FEATURE: Allow specifiying required paths when retrieving userinfo

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -78,10 +78,16 @@ end
 # We'll store the value in the user associated account's extra attribute hash using the full path as the key.
 DiscoursePluginRegistry.define_filtered_register :oauth2_basic_additional_json_paths
 
-# After authentication, we'll use this to confirm that the registered json paths are fulfilled,
-# or display an error message to the user.
+# After authentication, we'll use this to confirm that the registered json paths are fulfilled, or display an error.
 # This requires SiteSetting.oauth2_fetch_user_details? to be true, and can be used with
 # DiscoursePluginRegistry.oauth2_basic_additional_json_paths.
+#
+# Example usage:
+# DiscoursePluginRegistry.register_oauth2_basic_required_json_path({
+#   path: "extra:data.is_allowed_user",
+#   required_value: true,
+#   error_message: I18n.t("auth.user_not_allowed")
+# }, self)
 DiscoursePluginRegistry.define_filtered_register :oauth2_basic_required_json_paths
 
 class ::OAuth2BasicAuthenticator < Auth::ManagedAuthenticator

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -122,6 +122,54 @@ describe OAuth2BasicAuthenticator do
           expect(associated_account.extra[custom_path]).to eq("received")
         end
       end
+
+      describe "required attributes" do
+        after { DiscoursePluginRegistry.reset_register!(:oauth2_basic_required_json_paths) }
+
+        it "'authenticates' successfully if required json path is fulfilled" do
+          DiscoursePluginRegistry.register_oauth2_basic_additional_json_path(
+            "account.is_legit",
+            Plugin::Instance.new,
+          )
+          DiscoursePluginRegistry.register_oauth2_basic_required_json_path(
+            { path: "extra:account.is_legit", required_value: true },
+            Plugin::Instance.new,
+          )
+
+          response = {
+            status: 200,
+            body: '{"account":{"email":"newemail@example.com","is_legit":true}}',
+          }
+          stub_request(:get, SiteSetting.oauth2_user_json_url).to_return(response)
+
+          result = authenticator.after_authenticate(auth)
+          expect(result.failed).to eq(false)
+        end
+
+        it "fails 'authentication' if required json path is unfulfilled" do
+          DiscoursePluginRegistry.register_oauth2_basic_additional_json_path(
+            "account.is_legit",
+            Plugin::Instance.new,
+          )
+          DiscoursePluginRegistry.register_oauth2_basic_required_json_path(
+            {
+              path: "extra:account.is_legit",
+              required_value: true,
+              error_message: "You're not legit",
+            },
+            Plugin::Instance.new,
+          )
+          response = {
+            status: 200,
+            body: '{"account":{"email":"newemail@example.com","is_legit":false}}',
+          }
+          stub_request(:get, SiteSetting.oauth2_user_json_url).to_return(response)
+
+          result = authenticator.after_authenticate(auth)
+          expect(result.failed).to eq(true)
+          expect(result.failed_reason).to eq("You're not legit")
+        end
+      end
     end
 
     describe "avatar downloading" do


### PR DESCRIPTION
When retrieving `userinfo` with `oauth2_fetch_user_details=true`, we sometimes want to disallow account creation if an attribute is not fulfilled.

This PR adds a new register `oauth2_basic_required_json_path` which will kick in when retrieving `userinfo`. It can be used this way:
```
DiscoursePluginRegistry.register_oauth2_basic_required_json_path({
      path: "extra:account.is_allowed_member",
      required_value: true,
      error_message: I18n.t("login.unfulfilled_requirement"),
    }, self)
```

If the attribute does not satisfy the required value, we will see the specified error message when returning to the forum. The account is not created.

<img width="555" alt="Screenshot 2024-01-31 at 12 45 44 PM" src="https://github.com/discourse/discourse-oauth2-basic/assets/1555215/cac0e4c8-3521-44f4-8d63-e50d70b285e1">


### Alternatives

The alternatives I can think of is
1. monkey patching 
2. creating a new authenticator 

(1) is definitely brittle, and (2) does feel like there will be a lot of copy-work even within the method itself.

3. David did point out `on(:after_auth)` exists. However the event happens slightly too late - the associated account would have been created already, and the `result` would not contain the required attribute.