### PR TITLE
Removing "and avatar" that is not supported from the doc

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,7 +11,7 @@ en:
     oauth2_token_url: "Token URL for OAuth2"
     oauth2_token_url_method: "Method used to fetch the Token URL"
     oauth2_callback_user_id_path: "Path in the token response to the user id. eg: params.info.uuid"
-    oauth2_callback_user_info_paths: "Paths in the token response to other user properties. Supported properties are name, username, email, email_verified and avatar. Format is property:path, eg: name:params.info.name"
+    oauth2_callback_user_info_paths: "Paths in the token response to other user properties. Supported properties are name, username, email and email_verified. Format is property:path, eg: name:params.info.name"
     oauth2_fetch_user_details: "Fetch user JSON for OAuth2"
     oauth2_user_json_url: "URL to fetch user JSON for OAuth2 (note we replace :id with the id returned by OAuth call and :token with the token id)"
     oauth2_user_json_url_method: "Method used to fetch the user JSON URL"

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -16,7 +16,7 @@ es:
     oauth2_token_url: "URL de token para OAuth2"
     oauth2_token_url_method: "Método utilizado para obtener la URL del token"
     oauth2_callback_user_id_path: "Ruta en la respuesta del token a la identificación del usuario. Ejemplo: params.info.uuid"
-    oauth2_callback_user_info_paths: "Rutas en la respuesta del token a otras propiedades del usuario. Las propiedades admitidas son nombre, nombre de usuario, correo electrónico, email_verified y avatar. El formato es property:path, por ejemplo: name:params.info.name"
+    oauth2_callback_user_info_paths: "Rutas en la respuesta del token a otras propiedades del usuario. Las propiedades admitidas son nombre, nombre de usuario, correo electrónico y email_verified. El formato es property:path, por ejemplo: name:params.info.name"
     oauth2_fetch_user_details: "Obtener usuario JSON para OAuth2"
     oauth2_user_json_url: "URL para obtener el usuario JSON para OAuth2 (ten en cuenta que reemplazamos :id con la id devuelta por OAuth call y :token con la id del token)"
     oauth2_user_json_url_method: "Método utilizado para obtener la URL JSON del usuario"

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -16,7 +16,7 @@ fr:
     oauth2_token_url: "URL du jeton pour l'option OAuth2"
     oauth2_token_url_method: "Méthode utilisée pour récupérer l'adresse URL du jeton"
     oauth2_callback_user_id_path: "Chemin dans la réponse du jeton vers l'ID utilisateur (p. ex.,  params.info.uuid)"
-    oauth2_callback_user_info_paths: "Chemins dans la réponse de jeton vers d'autres propriétés de l'utilisateur. Les propriétés prises en charge sont le nom, le nom d'utilisateur, l'adresse e-mail, l'adresse e-mail vérifiée et l'avatar (name, username, email, email_verified et avatar). Le format est le suivant : property:path (p. ex. : name:params.info.name)"
+    oauth2_callback_user_info_paths: "Chemins dans la réponse de jeton vers d'autres propriétés de l'utilisateur. Les propriétés prises en charge sont le nom, le nom d'utilisateur, l'adresse e-mail et l'adresse e-mail vérifiée (name, username, email, email_verified). Le format est le suivant : property:path (p. ex. : name:params.info.name)"
     oauth2_fetch_user_details: "Récupérer le JSON de l'utilisateur pour l'option OAuth2"
     oauth2_user_json_url: "URL pour récupérer le JSON de l'utilisateur pour l'option OAuth2 (remarque : nous remplaçons :id par l'identifiant renvoyé par l'appel OAuth et :token par l'identifiant du jeton)."
     oauth2_user_json_url_method: "Méthode utilisée pour récupérer l'adresse URL du JSON de l'utilisateur"

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -16,7 +16,7 @@ it:
     oauth2_token_url: "URL del token per OAuth2"
     oauth2_token_url_method: "Metodo utilizzato per recuperare l'URL del token"
     oauth2_callback_user_id_path: "Percorso nella risposta del token all'id utente. es: params.info.uuid"
-    oauth2_callback_user_info_paths: "Percorsi nella risposta del token alle altre proprietà utente. Le proprietà supportate sono name, username, email, email_verified e avatar. Il formato è property:path, es: name:params.info.name"
+    oauth2_callback_user_info_paths: "Percorsi nella risposta del token alle altre proprietà utente. Le proprietà supportate sono name, username, email et email_verified. Il formato è property:path, es: name:params.info.name"
     oauth2_fetch_user_details: "Recupera il JSON dell'utente per OAuth2"
     oauth2_user_json_url: "URL per recuperare il JOSN dell'utente per OAuth2 (nota: sostituiamo :id con l'id restituito dalla chiamata OAuth e :token con l'id token)"
     oauth2_user_json_url_method: "Metodo utilizzato per recuperare l'URL JSON dell'utente"


### PR DESCRIPTION
This PR refers to this issue:
https://meta.discourse.org/t/oauth2-plugin-avatar-not-used/295121

Since I can't find and fix the bug, at least adjusting the documentation makes sense to me. This only affects the initial token documentation, since the avatar works with the a-postiori json query.

I propagated to only to the languages I understand. If it makes sense for the plugin maintainers to propagate it to all languages we should do that, but I wanted to wait until confirmation that the issue will not be otherwise fixed.