### PR TITLE
FIX: Appropriately assign  values when fetching user details

### DIFF
--- a/lib/oauth2_basic_authenticator.rb
+++ b/lib/oauth2_basic_authenticator.rb
@@ -84,7 +84,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
     return nil unless fragment.is_a?(Hash) || fragment.is_a?(Array)
     first_seg = segments[seg_index].scan(/([\d+])/).length > 0 ? first_seg.split("[")[0] : first_seg
     if fragment.is_a?(Hash)
-      deref = fragment[first_seg] || fragment[first_seg.to_sym]
+      deref = fragment.key?(first_seg) ? fragment[first_seg] : fragment[first_seg.to_sym]
     else
       array_index = 0
       if (seg_index > 0)
@@ -98,7 +98,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       end
     end
 
-    if (deref.blank? || seg_index == segments.size - 1)
+    if deref.blank? || seg_index == segments.size - 1
       deref
     else
       seg_index += 1
@@ -113,7 +113,8 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       path = path.gsub(".[].", ".").gsub(".[", "[")
       segments = parse_segments(path)
       val = walk_path(user_json, segments)
-      result[prop] = val if val.present?
+      # [] should be nil, false should be false
+      result[prop] = val.blank? ? (val == [] ? nil : val) : val
     end
   end
 

--- a/lib/oauth2_basic_authenticator.rb
+++ b/lib/oauth2_basic_authenticator.rb
@@ -84,7 +84,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
     return nil unless fragment.is_a?(Hash) || fragment.is_a?(Array)
     first_seg = segments[seg_index].scan(/([\d+])/).length > 0 ? first_seg.split("[")[0] : first_seg
     if fragment.is_a?(Hash)
-      deref = fragment.key?(first_seg) ? fragment[first_seg] : fragment[first_seg.to_sym]
+      deref = fragment[first_seg]
     else
       array_index = 0
       if (seg_index > 0)

--- a/lib/oauth2_basic_authenticator.rb
+++ b/lib/oauth2_basic_authenticator.rb
@@ -114,7 +114,7 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       segments = parse_segments(path)
       val = walk_path(user_json, segments)
       # [] should be nil, false should be false
-      result[prop] = val.blank? ? (val == [] ? nil : val) : val
+      result[prop] = val.presence || (val == [] ? nil : val)
     end
   end
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -312,6 +312,21 @@ describe OAuth2BasicAuthenticator do
     expect(result).to eq "http://example.com/1.png"
   end
 
+  it "can walk json and appropriately assign a `false`" do
+    authenticator = OAuth2BasicAuthenticator.new
+    json_string = '{"user":{"id":1234, "data": {"address":"test@example.com", "is_cat": false}}}'
+    SiteSetting.oauth2_json_email_verified_path = "user.data.is_cat"
+    result =
+      authenticator.json_walk(
+        {},
+        JSON.parse(json_string),
+        "extra:user.data.is_cat",
+        custom_path: "user.data.is_cat",
+      )
+
+    expect(result).to eq false
+  end
+
   describe "token_callback" do
     let(:user) { Fabricate(:user) }
     let(:strategy) { OmniAuth::Strategies::Oauth2Basic.new({}) }


### PR DESCRIPTION
Currently, in a user json with `false` values, due to a `||` operator, the value incorrectly evaluates to the right hand side. This was causing an issue.

e.g.
```
deref = fragment[first_seg] || fragment[first_seg.to_sym]
```

This PR fixes that and appropriately assigns `false` to the specified path for user details.