### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20190724055909_move_to_managed_authenticator.rb
+++ b/db/migrate/20190724055909_move_to_managed_authenticator.rb
@@ -22,4 +22,8 @@ class MoveToManagedAuthenticator < ActiveRecord::Migration[5.2]
     DO NOTHING
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.