### PR TITLE
UX: Update name in admin plugins page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Replace `DISCOURSE_HOST` with the appropriate value, and make sure you are
 using `https` if enabled. The OAuth2 provider should supply you with a
 client ID and secret, as well as a couple of URLs.
 
-Visit your **Admin** > **Settings** > **Login** and fill in the basic
+Visit your **Admin** > **Settings** > **OAuth2 Login** and fill in the basic
 configuration for the OAuth2 provider:
 
 - `oauth2_enabled` - check this off to enable the feature

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3,3 +3,7 @@ en:
     login:
       oauth2_basic:
         name: "OAuth 2"
+    admin:
+      site_settings:
+        categories:
+          discourse_oauth2_basic: "OAuth2 Login"


### PR DESCRIPTION
From "Login" to "OAuth2 Login" so that it is easier to distinguish from the other login methods.