### PR TITLE
FIX: mark oauth2_client_secret as secret

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,9 @@ login:
     default: false
     client: true
   oauth2_client_id: ""
-  oauth2_client_secret: ""
+  oauth2_client_secret:
+    default: ""
+    secret: true
   oauth2_authorize_url: ""
   oauth2_authorize_signup_url: ""
   oauth2_token_url: ""


### PR DESCRIPTION
The `oauth2_client_secret` should be marked as secret to mask it by default in
the admin UI.
